### PR TITLE
Fixed 1.17 empty Iterator

### DIFF
--- a/entity-plugin/src/main/kotlin/de/fllip/entity/plugin/entity/packet/MetadataPacketCreator.kt
+++ b/entity-plugin/src/main/kotlin/de/fllip/entity/plugin/entity/packet/MetadataPacketCreator.kt
@@ -59,7 +59,7 @@ class MetadataPacketCreator : AbstractEntityPacketCreator() {
         return createPacket(PacketType.Play.Server.ENTITY_METADATA, entity.getEntityId()).apply {
             modifier.writeDefaults()
 
-            val dataWatcher = WrappedDataWatcher(watchableCollectionModifier.read(0))
+            val dataWatcher = WrappedDataWatcher()
 
             val nameValue =
                 WrappedDataWatcher.WrappedDataWatcherObject(


### PR DESCRIPTION
"That watchable collection is going to be null because you just created the packet. The error in the data watcher could probably stand to be more helpful, but that's more or less the expected behavior. You could create an empty data watcher instead, or one from the entity" - dmulloy2

Linked to ProtocolLib issue: https://github.com/dmulloy2/ProtocolLib/issues/1253